### PR TITLE
Fix empty references parsing

### DIFF
--- a/src/Nix/NarInfo/Parser.hs
+++ b/src/Nix/NarInfo/Parser.hs
@@ -21,7 +21,7 @@ import qualified Data.Attoparsec.Text
 parseNarInfo :: Parser (NarInfo FilePath Text Text)
 parseNarInfo = parseNarInfoWith pathParse textParse hashParse
   where
-    textParse = Data.Attoparsec.Text.takeWhile (not . Data.Char.isSpace)
+    textParse = Data.Attoparsec.Text.takeWhile1 (not . Data.Char.isSpace)
     pathParse _hasPrefix = Data.Text.unpack <$> textParse
     hashParse = textParse
 

--- a/test/ParseSpec.hs
+++ b/test/ParseSpec.hs
@@ -11,18 +11,27 @@ import Data.Text.Lazy.IO
 
 import SpecHelper
 
-roundTrip fname = do
+parseSample fname = do
   txt <- Data.Text.IO.readFile $ "./test/samples/" ++ fname
   case Data.Attoparsec.Text.parseOnly parseNarInfo txt of
     Left e -> error e
-    Right ni -> do
-      let built = Data.Text.Lazy.Builder.toLazyText $ buildNarInfo ni
-      (Data.Text.Lazy.toStrict built) `shouldBe` txt
+    Right ni -> pure (txt, ni)
+
+roundTrip fname = do
+  (txt, ni) <- parseSample fname
+  let built = Data.Text.Lazy.Builder.toLazyText $ buildNarInfo ni
+  (Data.Text.Lazy.toStrict built) `shouldBe` txt
+
+referencesEmpty fname = do
+  (_, ni) <- parseSample fname
+  references ni `shouldSatisfy` Prelude.null
 
 spec :: Spec
 spec = do
   it "roundtrips samples" $ do
-    mapM_ (roundTrip . show) [0]
+    mapM_ (roundTrip . show) [0, 1]
+  it "parses empty references" $ do
+    mapM_ (referencesEmpty . show) [1]
 
 main :: IO ()
 main = hspec spec

--- a/test/samples/1
+++ b/test/samples/1
@@ -1,0 +1,10 @@
+StorePath: /nix/store/jd99cyc0251p0i5y69w8mqjcai8mcq7h-xgcc-12.2.0-libgcc
+URL: nar/19sqyfks8im2vwa88scbr59p7fsiqlrzjchzgfsiv6phsj347cr8.nar.xz
+Compression: xz
+FileHash: sha256:19sqyfks8im2vwa88scbr59p7fsiqlrzjchzgfsiv6phsj347cr8
+FileSize: 51168
+NarHash: sha256:1kkya9i8g3x0r9qwisb7ln5iacqbydcijz91isksgxs6qlz4vhrs
+NarSize: 142624
+References: 
+Deriver: q072lsl54bjjlgsj06w7fb431cz2ckci-xgcc-12.2.0.drv
+Sig: cache.nixos.org-1:3HOgd2rfiGhjncReE/SkoNmYf0mwCgQGAkjq4lFsr+sZQlQ7R33T/G6fnzEcnnxHVxuxf1Su03miIFCK1xoCBA==


### PR DESCRIPTION
An empty references list was parsed as a singleton set with an empty string. Change this to parse as an empty set. Add sample and test.

Sample from URL:
https://cache.nixos.org/jd99cyc0251p0i5y69w8mqjcai8mcq7h.narinfo