### PR TITLE
Render and parse the content-address field as CA:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version [0.1.1.3](https://github.com/sorki/nix-narinfo/compare/0.1.1.2...0.1.1.3)
+
+* Render and parse the content-address field as `CA:` to match Nix's
+  case-sensitive narinfo key (was `Ca:`, which Nix silently ignored)
+
 # Version [0.1.1.2](https://github.com/sorki/nix-narinfo/compare/0.1.1.1...0.1.1.2) (2025-05-16)
 
 * Fix testsuite build for GHC 9.10.2 [#9](https://github.com/sorki/nix-narinfo/pull/9)

--- a/nix-narinfo.cabal
+++ b/nix-narinfo.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                nix-narinfo
-version:             0.1.1.2
+version:             0.1.1.3
 synopsis:            Parse and render .narinfo files
 description:         Support for parsing and rendering Nix .narinfo files
 homepage:            https://github.com/sorki/nix-narinfo

--- a/src/Nix/NarInfo/Builder.hs
+++ b/src/Nix/NarInfo/Builder.hs
@@ -48,7 +48,7 @@ buildNarInfoWith filepath string hash (NarInfo{..}) =
   <> optKey  "Deriver"     deriver
   <> optKey  "System"      system
   <> optKey  "Sig"         sig
-  <> optKey  "Ca"          ca
+  <> optKey  "CA"          ca
   where
     key' k v    = k <> ": " <> v <> "\n"
     key k v     = key' k (string v)

--- a/src/Nix/NarInfo/Parser.hs
+++ b/src/Nix/NarInfo/Parser.hs
@@ -45,7 +45,7 @@ parseNarInfoWith pathParser textParser hashParser = do
   deriver     <- optKey "Deriver"
   system      <- optKey "System"
   sig         <- optKey "Sig"
-  ca          <- optKey "Ca"
+  ca          <- optKey "CA"
 
   return $ NarInfo {..}
   where


### PR DESCRIPTION
Nix's narinfo parser matches the content-address key **case-sensitively** as `CA:` (`src/libstore/nar-info.cc`: `else if (name == "CA")`) and silently ignores any other spelling. Nix's own serializer likewise emits `CA: `.

`nix-narinfo` currently emits and parses `Ca:`, so the content-address field never round-trips with a real Nix client: a narinfo this library renders is registered by Nix as input-addressed (the `Ca` line is dropped), and a narinfo Nix wrote is parsed here with `ca = Nothing`.

This fixes both sides:

- `Builder.hs`: `optKey "Ca" ca` -> `optKey "CA" ca`
- `Parser.hs`: `optKey "Ca"` -> `optKey "CA"`

The build/parse round-trip property test stays green (both sides change in lockstep), and the golden samples contain no content-address line so they're unaffected. Version bumped to 0.1.1.3 with a CHANGELOG entry.